### PR TITLE
feat: Implement tab-level access control for Access Keys

### DIFF
--- a/app/api/admin/modules/access-key/route.ts
+++ b/app/api/admin/modules/access-key/route.ts
@@ -1,0 +1,187 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { moduleRegistry } from "@/lib/modules/registry";
+import { prisma } from "@/lib/prisma";
+import { AuditService } from "@/lib/services/audit-service";
+
+/**
+ * allowAccessKey設定を更新するAPI
+ *
+ * メニューレベル: { type: "menu", menuId: string, allowAccessKey: boolean }
+ * タブレベル: { type: "tab", menuId: string, tabId: string, allowAccessKey: boolean }
+ */
+export async function PATCH(request: Request) {
+  try {
+    const session = await auth();
+
+    if (!session || session.user.role !== "ADMIN") {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const { type, menuId, tabId, allowAccessKey } = body;
+
+    // バリデーション
+    if (!type || !menuId || typeof allowAccessKey !== "boolean") {
+      return NextResponse.json(
+        { error: "type, menuId, and allowAccessKey are required" },
+        { status: 400 }
+      );
+    }
+
+    if (type !== "menu" && type !== "tab") {
+      return NextResponse.json(
+        { error: "type must be 'menu' or 'tab'" },
+        { status: 400 }
+      );
+    }
+
+    if (type === "tab" && !tabId) {
+      return NextResponse.json(
+        { error: "tabId is required for tab type" },
+        { status: 400 }
+      );
+    }
+
+    // メニューの存在確認
+    let foundModule: (typeof moduleRegistry)[string] | null = null;
+    let foundMenu: { id: string; name: string; nameJa?: string; tabs?: unknown[] } | null = null;
+    let foundTab: { id: string; name: string; nameJa?: string } | null = null;
+
+    for (const module of Object.values(moduleRegistry)) {
+      const menu = module.menus.find((m) => m.id === menuId);
+      if (menu) {
+        foundModule = module;
+        foundMenu = menu;
+        if (type === "tab" && menu.tabs) {
+          const tab = menu.tabs.find((t) => t.id === tabId);
+          if (tab) {
+            foundTab = tab;
+          }
+        }
+        break;
+      }
+    }
+
+    if (!foundMenu || !foundModule) {
+      return NextResponse.json(
+        { error: "Menu not found" },
+        { status: 404 }
+      );
+    }
+
+    if (type === "tab" && !foundTab) {
+      return NextResponse.json(
+        { error: "Tab not found" },
+        { status: 404 }
+      );
+    }
+
+    // SystemSettingに保存
+    let settingKey: string;
+    if (type === "menu") {
+      settingKey = `menu_allow_access_key_${menuId}`;
+    } else {
+      settingKey = `tab_allow_access_key_${menuId}_${tabId}`;
+    }
+
+    await prisma.systemSetting.upsert({
+      where: { key: settingKey },
+      update: { value: allowAccessKey.toString() },
+      create: { key: settingKey, value: allowAccessKey.toString() },
+    });
+
+    // 監査ログに記録
+    await AuditService.log({
+      action: "ACCESS_KEY_PERMISSION_UPDATE",
+      category: "MODULE",
+      userId: session.user.id,
+      targetId: type === "menu" ? menuId : `${menuId}/${tabId}`,
+      targetType: type === "menu" ? "Menu" : "Tab",
+      details: {
+        type,
+        menuId,
+        menuName: foundMenu.name,
+        menuNameJa: foundMenu.nameJa,
+        ...(type === "tab" && {
+          tabId,
+          tabName: foundTab?.name,
+          tabNameJa: foundTab?.nameJa,
+        }),
+        allowAccessKey,
+      },
+    }).catch(() => {});
+
+    return NextResponse.json({
+      success: true,
+      type,
+      menuId,
+      ...(type === "tab" && { tabId }),
+      allowAccessKey,
+    });
+  } catch (error) {
+    console.error("Error updating allowAccessKey setting:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * allowAccessKey設定をデフォルトにリセットするAPI
+ */
+export async function DELETE(request: Request) {
+  try {
+    const session = await auth();
+
+    if (!session || session.user.role !== "ADMIN") {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const type = searchParams.get("type");
+    const menuId = searchParams.get("menuId");
+    const tabId = searchParams.get("tabId");
+
+    if (!type || !menuId) {
+      return NextResponse.json(
+        { error: "type and menuId are required" },
+        { status: 400 }
+      );
+    }
+
+    if (type === "tab" && !tabId) {
+      return NextResponse.json(
+        { error: "tabId is required for tab type" },
+        { status: 400 }
+      );
+    }
+
+    // SystemSettingから削除（デフォルト値にリセット）
+    let settingKey: string;
+    if (type === "menu") {
+      settingKey = `menu_allow_access_key_${menuId}`;
+    } else {
+      settingKey = `tab_allow_access_key_${menuId}_${tabId}`;
+    }
+
+    await prisma.systemSetting.deleteMany({
+      where: { key: settingKey },
+    });
+
+    return NextResponse.json({
+      success: true,
+      type,
+      menuId,
+      ...(type === "tab" && { tabId }),
+      reset: true,
+    });
+  } catch (error) {
+    console.error("Error resetting allowAccessKey setting:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/admin/modules/route.ts
+++ b/app/api/admin/modules/route.ts
@@ -35,6 +35,20 @@ export async function GET() {
       }
     }
 
+    // モジュール有効状態のオーバーライドを取得
+    const moduleEnabledSettings = await prisma.systemSetting.findMany({
+      where: {
+        key: {
+          startsWith: "module_enabled_",
+        },
+      },
+    });
+    const moduleEnabledOverrides: Record<string, boolean> = {};
+    for (const setting of moduleEnabledSettings) {
+      const moduleId = setting.key.replace("module_enabled_", "");
+      moduleEnabledOverrides[moduleId] = setting.value === "true";
+    }
+
     // コンテナステータスをチェックする関数
     const checkContainerStatus = async (containerId: string): Promise<boolean> => {
       try {
@@ -81,13 +95,16 @@ export async function GET() {
             )
           : [];
 
+        // モジュール有効状態: SystemSettingの値があればそれを使用、なければデフォルト値
+        const isEnabled = moduleEnabledOverrides[module.id] ?? module.enabled;
+
         return {
           id: module.id,
           name: module.name,
           nameJa: module.nameJa,
           description: module.description,
           descriptionJa: module.descriptionJa,
-          enabled: module.enabled,
+          enabled: isEnabled,
           type: isCore ? ("core" as const) : ("addon" as const),
           menuCount: module.menus.filter((m) => menuEnabledOverrides[m.id] ?? m.enabled).length,
           menus: module.menus.map((menu) => ({

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -74,6 +74,9 @@ export function Header({ session, language = "en" }: HeaderProps) {
   const isAdmin = pathname === "/admin";
   const isDataImport = pathname === "/data-import";
   const isSettings = pathname === "/settings";
+  const isDataManagement = pathname === "/admin/data-management";
+  const isEvaluationMaster = pathname === "/admin/evaluation-master";
+  const isEvaluationRag = pathname === "/admin/evaluation-rag";
 
   // 組織分析タブ
   const analyticsTab = searchParams.get("tab") || "overview";
@@ -191,6 +194,39 @@ export function Header({ session, language = "en" }: HeaderProps) {
     },
   ];
 
+  // 組織データ管理タブ（レジストリから取得）
+  const dataManagementTab = searchParams.get("tab") || "import";
+  const registryDataManagementTabs = getTabsByMenuPath("/admin/data-management");
+  const dataManagementTabs =
+    registryDataManagementTabs?.map((tab) => ({
+      name: language === "ja" ? tab.nameJa : tab.name,
+      icon: tab.icon,
+      path: `/admin/data-management?tab=${tab.id}`,
+      active: dataManagementTab === tab.id,
+    })) || [];
+
+  // 評価マスタタブ（レジストリから取得）
+  const evaluationMasterTab = searchParams.get("tab") || "periods";
+  const registryEvaluationMasterTabs = getTabsByMenuPath("/admin/evaluation-master");
+  const evaluationMasterTabs =
+    registryEvaluationMasterTabs?.map((tab) => ({
+      name: language === "ja" ? tab.nameJa : tab.name,
+      icon: tab.icon,
+      path: `/admin/evaluation-master?tab=${tab.id}`,
+      active: evaluationMasterTab === tab.id,
+    })) || [];
+
+  // 評価AIサポートタブ（レジストリから取得）
+  const evaluationRagTab = searchParams.get("tab") || "knowledge-base";
+  const registryEvaluationRagTabs = getTabsByMenuPath("/admin/evaluation-rag");
+  const evaluationRagTabs =
+    registryEvaluationRagTabs?.map((tab) => ({
+      name: language === "ja" ? tab.nameJa : tab.name,
+      icon: tab.icon,
+      path: `/admin/evaluation-rag?tab=${tab.id}`,
+      active: evaluationRagTab === tab.id,
+    })) || [];
+
   const renderTabs = (tabs: TabItem[], label: string) => (
     <div className="border-t border-border bg-muted">
       <nav className="flex gap-1 px-6" aria-label={label}>
@@ -276,6 +312,9 @@ export function Header({ session, language = "en" }: HeaderProps) {
       {isAdmin && renderTabs(adminTabs, "Admin Tabs")}
       {isDataImport && renderTabs(dataImportTabs, "Data Import Tabs")}
       {isSettings && renderTabs(settingsTabs, "Settings Tabs")}
+      {isDataManagement && renderTabs(dataManagementTabs, "Data Management Tabs")}
+      {isEvaluationMaster && renderTabs(evaluationMasterTabs, "Evaluation Master Tabs")}
+      {isEvaluationRag && renderTabs(evaluationRagTabs, "Evaluation AI Support Tabs")}
     </header>
   );
 }

--- a/lib/access-keys.ts
+++ b/lib/access-keys.ts
@@ -1,13 +1,27 @@
 import { prisma } from "./prisma";
 
 /**
- * Get menu paths that the user has access to via Access Keys
- * @param userId - The user ID
- * @returns Array of menu paths the user can access
+ * アクセスキーによるアクセス権限情報
  */
-export async function getUserAccessibleMenus(
+export interface AccessKeyPermissions {
+  menuPaths: string[];
+  // menuPath -> tabIds のマッピング（タブレベルの権限がある場合）
+  tabPermissions: Record<string, string[]>;
+}
+
+/**
+ * Get menu paths and tab permissions that the user has access to via Access Keys
+ * @param userId - The user ID
+ * @returns AccessKeyPermissions object containing menu paths and tab permissions
+ */
+export async function getUserAccessKeyPermissions(
   userId: string,
-): Promise<string[]> {
+): Promise<AccessKeyPermissions> {
+  const result: AccessKeyPermissions = {
+    menuPaths: [],
+    tabPermissions: {},
+  };
+
   try {
     // Get all active Access Keys registered by this user
     const userAccessKeys = await prisma.userAccessKey.findMany({
@@ -15,11 +29,13 @@ export async function getUserAccessibleMenus(
         userId,
       },
       include: {
-        accessKey: true,
+        accessKey: {
+          include: {
+            permissions: true, // AccessKeyPermission を含める
+          },
+        },
       },
     });
-
-    const accessibleMenus: string[] = [];
 
     for (const userAccessKey of userAccessKeys) {
       const { accessKey } = userAccessKey;
@@ -35,19 +51,53 @@ export async function getUserAccessibleMenus(
         continue;
       }
 
-      // Parse menuPaths from JSON string
-      try {
-        const menuPaths = JSON.parse(accessKey.menuPaths) as string[];
-        accessibleMenus.push(...menuPaths);
-      } catch (error) {
-        console.error("Error parsing menuPaths:", error);
+      // 方法1: 後方互換性 - menuPaths JSON からパース
+      if (accessKey.menuPaths) {
+        try {
+          const menuPaths = JSON.parse(accessKey.menuPaths) as string[];
+          result.menuPaths.push(...menuPaths);
+        } catch (error) {
+          console.error("Error parsing menuPaths:", error);
+        }
+      }
+
+      // 方法2: Phase 2 - AccessKeyPermission からメニューパス・タブを取得
+      for (const permission of accessKey.permissions) {
+        if (permission.menuPath) {
+          result.menuPaths.push(permission.menuPath);
+
+          // タブレベルの権限がある場合
+          if (permission.granularity === "tab" && permission.tabId) {
+            if (!result.tabPermissions[permission.menuPath]) {
+              result.tabPermissions[permission.menuPath] = [];
+            }
+            result.tabPermissions[permission.menuPath].push(permission.tabId);
+          }
+        }
       }
     }
 
-    // Return unique menu paths
-    return [...new Set(accessibleMenus)];
+    // Remove duplicates
+    result.menuPaths = [...new Set(result.menuPaths)];
+    for (const menuPath in result.tabPermissions) {
+      result.tabPermissions[menuPath] = [...new Set(result.tabPermissions[menuPath])];
+    }
+
+    return result;
   } catch (error) {
-    console.error("Error getting user accessible menus:", error);
-    return [];
+    console.error("Error getting user access key permissions:", error);
+    return result;
   }
+}
+
+/**
+ * Get menu paths that the user has access to via Access Keys
+ * @param userId - The user ID
+ * @returns Array of menu paths the user can access
+ */
+export async function getUserAccessibleMenus(
+  userId: string,
+): Promise<string[]> {
+  const permissions = await getUserAccessKeyPermissions(userId);
+  return permissions.menuPaths;
 }

--- a/lib/auth/access-checker.ts
+++ b/lib/auth/access-checker.ts
@@ -58,7 +58,19 @@ export async function checkAccess(
         continue;
       }
 
-      // このアクセスキーがmenuPathへのアクセスを許可しているかチェック
+      // 方法1: AccessKey.menuPaths (JSON) からチェック
+      if (ak.menuPaths) {
+        try {
+          const menuPaths = JSON.parse(ak.menuPaths) as string[];
+          if (menuPaths.includes(menuPath)) {
+            return true;
+          }
+        } catch {
+          // JSON パースエラーは無視
+        }
+      }
+
+      // 方法2: AccessKeyPermission からチェック
       for (const akp of ak.permissions) {
         // 新しい粒度システム（Phase 2）
         if (akp.menuPath) {

--- a/lib/core-modules/system/module.tsx
+++ b/lib/core-modules/system/module.tsx
@@ -110,7 +110,7 @@ const adminTabs: AppTab[] = [
  *
  * システムの基本機能と管理機能を提供します。
  * - 全社員: ダッシュボード
- * - 管理者: ユーザ管理、アクセスキー管理
+ * - 管理者: システム環境（ユーザ管理、モジュール管理、アクセスキー管理等）
  */
 export const systemModule: AppModule = {
   id: "system",
@@ -200,36 +200,6 @@ export const systemModule: AppModule = {
       ),
       tabs: adminTabs,
       allowAccessKey: false, // メニュー全体ではなくタブ単位で制御
-    },
-    {
-      id: "accessKeyManagement",
-      moduleId: "system",
-      name: "Access Key Management",
-      nameJa: "アクセスキー管理",
-      path: "/access-keys",
-      menuGroup: "admin",
-      requiredRoles: ["ADMIN"],
-      enabled: false, // サイドバーに表示しない（管理画面のタブに統合）
-      order: 3,
-      description: "Manage access keys and permissions",
-      descriptionJa: "アクセスキーと権限を管理します",
-      icon: (
-        <svg
-          key="accessKeyManagement-icon"
-          className="w-5 h-5 flex-shrink-0"
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <path
-            key="icon-path"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z"
-          />
-        </svg>
-      ),
     },
   ],
 };

--- a/lib/services/audit-service.ts
+++ b/lib/services/audit-service.ts
@@ -30,7 +30,8 @@ export type AuditAction =
   | "ANNOUNCEMENT_DELETE"
   // MODULE
   | "MODULE_TOGGLE"
-  | "MENU_TOGGLE";
+  | "MENU_TOGGLE"
+  | "ACCESS_KEY_PERMISSION_UPDATE";
 
 export interface AuditLogInput {
   action: AuditAction;

--- a/middleware.ts
+++ b/middleware.ts
@@ -69,8 +69,10 @@ export default auth((req) => {
   }
 
   // Admin-only routes
-  const adminRoutes = ["/admin", "/admin/users", "/admin/api-keys"];
-  if (adminRoutes.some((route) => pathname.startsWith(route))) {
+  // 注意: アクセスキーによる権限委譲があるため、ミドルウェアでは厳密なロールチェックを行わない
+  // 各ページで checkAccess を使用して詳細なアクセス制御を行う
+  // ここでは /admin のトップページのみ ADMIN 専用として制限
+  if (pathname === "/admin") {
     if (session.user.role !== "ADMIN") {
       return NextResponse.redirect(new URL("/dashboard", req.url));
     }


### PR DESCRIPTION
## Summary

アクセスキーにタブレベルの粒度制御を実装し、管理者がメニュー全体ではなく特定のタブのみへのアクセスを許可できるようにしました。

## 変更ファイル（11ファイル）

| ファイル | 変更内容 |
|----------|----------|
| `lib/access-keys.ts` | `getUserAccessKeyPermissions()` 関数を追加（メニューパスとタブ権限を返す） |
| `app/api/admin/access-keys/route.ts` | トランザクションで `AccessKeyPermission` テーブルに権限を保存 |
| `lib/auth/access-checker.ts` | `AccessKey.menuPaths` (JSON) と `AccessKeyPermission` の両方をチェック |
| `middleware.ts` | 管理ルート保護を `/admin` 完全一致のみに変更 |
| `app/layout.tsx` | `tabPermissions` を Header に渡す |
| `components/Header.tsx` | 非ADMINユーザーのタブ表示をフィルタリング |
| `app/admin/AdminClient.tsx` | allowAccessKey 設定トグルUI |
| `app/api/admin/modules/route.ts` | allowAccessKey 設定をレスポンスに含める |
| `app/api/admin/modules/access-key/route.ts` | allowAccessKey 設定更新API（新規） |
| `lib/core-modules/system/module.tsx` | 未使用メニュー定義を削除 |
| `lib/services/audit-service.ts` | `ACCESS_KEY_PERMISSION_UPDATE` アクション追加 |

## 除外したファイル

- `app/admin/evaluation-master/page.tsx` - 人事評価モジュール固有（Addon機能）

## Test plan

- [ ] ADMINロールでアクセスキーを作成（タブレベル権限を指定）
- [ ] USERロールでアクセスキーを登録
- [ ] USERロールでログインし、許可されたタブのみが表示されることを確認
- [ ] モジュール管理画面でallowAccessKey設定のON/OFFが動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)