### PR TITLE
feat: Add tab-level permission support for Access Keys (Backend)

### DIFF
--- a/app/api/admin/modules/access-key/route.ts
+++ b/app/api/admin/modules/access-key/route.ts
@@ -1,0 +1,187 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { moduleRegistry } from "@/lib/modules/registry";
+import { prisma } from "@/lib/prisma";
+import { AuditService } from "@/lib/services/audit-service";
+
+/**
+ * allowAccessKey設定を更新するAPI
+ *
+ * メニューレベル: { type: "menu", menuId: string, allowAccessKey: boolean }
+ * タブレベル: { type: "tab", menuId: string, tabId: string, allowAccessKey: boolean }
+ */
+export async function PATCH(request: Request) {
+  try {
+    const session = await auth();
+
+    if (!session || session.user.role !== "ADMIN") {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const { type, menuId, tabId, allowAccessKey } = body;
+
+    // バリデーション
+    if (!type || !menuId || typeof allowAccessKey !== "boolean") {
+      return NextResponse.json(
+        { error: "type, menuId, and allowAccessKey are required" },
+        { status: 400 }
+      );
+    }
+
+    if (type !== "menu" && type !== "tab") {
+      return NextResponse.json(
+        { error: "type must be 'menu' or 'tab'" },
+        { status: 400 }
+      );
+    }
+
+    if (type === "tab" && !tabId) {
+      return NextResponse.json(
+        { error: "tabId is required for tab type" },
+        { status: 400 }
+      );
+    }
+
+    // メニューの存在確認
+    let foundModule: (typeof moduleRegistry)[string] | null = null;
+    let foundMenu: { id: string; name: string; nameJa?: string; tabs?: unknown[] } | null = null;
+    let foundTab: { id: string; name: string; nameJa?: string } | null = null;
+
+    for (const module of Object.values(moduleRegistry)) {
+      const menu = module.menus.find((m) => m.id === menuId);
+      if (menu) {
+        foundModule = module;
+        foundMenu = menu;
+        if (type === "tab" && menu.tabs) {
+          const tab = menu.tabs.find((t) => t.id === tabId);
+          if (tab) {
+            foundTab = tab;
+          }
+        }
+        break;
+      }
+    }
+
+    if (!foundMenu || !foundModule) {
+      return NextResponse.json(
+        { error: "Menu not found" },
+        { status: 404 }
+      );
+    }
+
+    if (type === "tab" && !foundTab) {
+      return NextResponse.json(
+        { error: "Tab not found" },
+        { status: 404 }
+      );
+    }
+
+    // SystemSettingに保存
+    let settingKey: string;
+    if (type === "menu") {
+      settingKey = `menu_allow_access_key_${menuId}`;
+    } else {
+      settingKey = `tab_allow_access_key_${menuId}_${tabId}`;
+    }
+
+    await prisma.systemSetting.upsert({
+      where: { key: settingKey },
+      update: { value: allowAccessKey.toString() },
+      create: { key: settingKey, value: allowAccessKey.toString() },
+    });
+
+    // 監査ログに記録
+    await AuditService.log({
+      action: "ACCESS_KEY_PERMISSION_UPDATE",
+      category: "MODULE",
+      userId: session.user.id,
+      targetId: type === "menu" ? menuId : `${menuId}/${tabId}`,
+      targetType: type === "menu" ? "Menu" : "Tab",
+      details: {
+        type,
+        menuId,
+        menuName: foundMenu.name,
+        menuNameJa: foundMenu.nameJa,
+        ...(type === "tab" && {
+          tabId,
+          tabName: foundTab?.name,
+          tabNameJa: foundTab?.nameJa,
+        }),
+        allowAccessKey,
+      },
+    }).catch(() => {});
+
+    return NextResponse.json({
+      success: true,
+      type,
+      menuId,
+      ...(type === "tab" && { tabId }),
+      allowAccessKey,
+    });
+  } catch (error) {
+    console.error("Error updating allowAccessKey setting:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * allowAccessKey設定をデフォルトにリセットするAPI
+ */
+export async function DELETE(request: Request) {
+  try {
+    const session = await auth();
+
+    if (!session || session.user.role !== "ADMIN") {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(request.url);
+    const type = searchParams.get("type");
+    const menuId = searchParams.get("menuId");
+    const tabId = searchParams.get("tabId");
+
+    if (!type || !menuId) {
+      return NextResponse.json(
+        { error: "type and menuId are required" },
+        { status: 400 }
+      );
+    }
+
+    if (type === "tab" && !tabId) {
+      return NextResponse.json(
+        { error: "tabId is required for tab type" },
+        { status: 400 }
+      );
+    }
+
+    // SystemSettingから削除（デフォルト値にリセット）
+    let settingKey: string;
+    if (type === "menu") {
+      settingKey = `menu_allow_access_key_${menuId}`;
+    } else {
+      settingKey = `tab_allow_access_key_${menuId}_${tabId}`;
+    }
+
+    await prisma.systemSetting.deleteMany({
+      where: { key: settingKey },
+    });
+
+    return NextResponse.json({
+      success: true,
+      type,
+      menuId,
+      ...(type === "tab" && { tabId }),
+      reset: true,
+    });
+  } catch (error) {
+    console.error("Error resetting allowAccessKey setting:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/lib/access-keys.ts
+++ b/lib/access-keys.ts
@@ -1,13 +1,27 @@
 import { prisma } from "./prisma";
 
 /**
- * Get menu paths that the user has access to via Access Keys
- * @param userId - The user ID
- * @returns Array of menu paths the user can access
+ * アクセスキーによるアクセス権限情報
  */
-export async function getUserAccessibleMenus(
+export interface AccessKeyPermissions {
+  menuPaths: string[];
+  // menuPath -> tabIds のマッピング（タブレベルの権限がある場合）
+  tabPermissions: Record<string, string[]>;
+}
+
+/**
+ * Get menu paths and tab permissions that the user has access to via Access Keys
+ * @param userId - The user ID
+ * @returns AccessKeyPermissions object containing menu paths and tab permissions
+ */
+export async function getUserAccessKeyPermissions(
   userId: string,
-): Promise<string[]> {
+): Promise<AccessKeyPermissions> {
+  const result: AccessKeyPermissions = {
+    menuPaths: [],
+    tabPermissions: {},
+  };
+
   try {
     // Get all active Access Keys registered by this user
     const userAccessKeys = await prisma.userAccessKey.findMany({
@@ -15,11 +29,13 @@ export async function getUserAccessibleMenus(
         userId,
       },
       include: {
-        accessKey: true,
+        accessKey: {
+          include: {
+            permissions: true, // AccessKeyPermission を含める
+          },
+        },
       },
     });
-
-    const accessibleMenus: string[] = [];
 
     for (const userAccessKey of userAccessKeys) {
       const { accessKey } = userAccessKey;
@@ -35,19 +51,53 @@ export async function getUserAccessibleMenus(
         continue;
       }
 
-      // Parse menuPaths from JSON string
-      try {
-        const menuPaths = JSON.parse(accessKey.menuPaths) as string[];
-        accessibleMenus.push(...menuPaths);
-      } catch (error) {
-        console.error("Error parsing menuPaths:", error);
+      // 方法1: 後方互換性 - menuPaths JSON からパース
+      if (accessKey.menuPaths) {
+        try {
+          const menuPaths = JSON.parse(accessKey.menuPaths) as string[];
+          result.menuPaths.push(...menuPaths);
+        } catch (error) {
+          console.error("Error parsing menuPaths:", error);
+        }
+      }
+
+      // 方法2: Phase 2 - AccessKeyPermission からメニューパス・タブを取得
+      for (const permission of accessKey.permissions) {
+        if (permission.menuPath) {
+          result.menuPaths.push(permission.menuPath);
+
+          // タブレベルの権限がある場合
+          if (permission.granularity === "tab" && permission.tabId) {
+            if (!result.tabPermissions[permission.menuPath]) {
+              result.tabPermissions[permission.menuPath] = [];
+            }
+            result.tabPermissions[permission.menuPath].push(permission.tabId);
+          }
+        }
       }
     }
 
-    // Return unique menu paths
-    return [...new Set(accessibleMenus)];
+    // Remove duplicates
+    result.menuPaths = [...new Set(result.menuPaths)];
+    for (const menuPath in result.tabPermissions) {
+      result.tabPermissions[menuPath] = [...new Set(result.tabPermissions[menuPath])];
+    }
+
+    return result;
   } catch (error) {
-    console.error("Error getting user accessible menus:", error);
-    return [];
+    console.error("Error getting user access key permissions:", error);
+    return result;
   }
+}
+
+/**
+ * Get menu paths that the user has access to via Access Keys
+ * @param userId - The user ID
+ * @returns Array of menu paths the user can access
+ */
+export async function getUserAccessibleMenus(
+  userId: string,
+): Promise<string[]> {
+  const permissions = await getUserAccessKeyPermissions(userId);
+  return permissions.menuPaths;
 }

--- a/lib/auth/access-checker.ts
+++ b/lib/auth/access-checker.ts
@@ -58,7 +58,19 @@ export async function checkAccess(
         continue;
       }
 
-      // このアクセスキーがmenuPathへのアクセスを許可しているかチェック
+      // 方法1: AccessKey.menuPaths (JSON) からチェック
+      if (ak.menuPaths) {
+        try {
+          const menuPaths = JSON.parse(ak.menuPaths) as string[];
+          if (menuPaths.includes(menuPath)) {
+            return true;
+          }
+        } catch {
+          // JSON パースエラーは無視
+        }
+      }
+
+      // 方法2: AccessKeyPermission からチェック
       for (const akp of ak.permissions) {
         // 新しい粒度システム（Phase 2）
         if (akp.menuPath) {

--- a/lib/core-modules/system/module.tsx
+++ b/lib/core-modules/system/module.tsx
@@ -110,7 +110,7 @@ const adminTabs: AppTab[] = [
  *
  * システムの基本機能と管理機能を提供します。
  * - 全社員: ダッシュボード
- * - 管理者: ユーザ管理、アクセスキー管理
+ * - 管理者: システム環境（ユーザ管理、モジュール管理、アクセスキー管理等）
  */
 export const systemModule: AppModule = {
   id: "system",
@@ -200,36 +200,6 @@ export const systemModule: AppModule = {
       ),
       tabs: adminTabs,
       allowAccessKey: false, // メニュー全体ではなくタブ単位で制御
-    },
-    {
-      id: "accessKeyManagement",
-      moduleId: "system",
-      name: "Access Key Management",
-      nameJa: "アクセスキー管理",
-      path: "/access-keys",
-      menuGroup: "admin",
-      requiredRoles: ["ADMIN"],
-      enabled: false, // サイドバーに表示しない（管理画面のタブに統合）
-      order: 3,
-      description: "Manage access keys and permissions",
-      descriptionJa: "アクセスキーと権限を管理します",
-      icon: (
-        <svg
-          key="accessKeyManagement-icon"
-          className="w-5 h-5 flex-shrink-0"
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <path
-            key="icon-path"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z"
-          />
-        </svg>
-      ),
     },
   ],
 };

--- a/lib/services/audit-service.ts
+++ b/lib/services/audit-service.ts
@@ -30,7 +30,8 @@ export type AuditAction =
   | "ANNOUNCEMENT_DELETE"
   // MODULE
   | "MODULE_TOGGLE"
-  | "MENU_TOGGLE";
+  | "MENU_TOGGLE"
+  | "ACCESS_KEY_PERMISSION_UPDATE";
 
 export interface AuditLogInput {
   action: AuditAction;


### PR DESCRIPTION
## Summary

アクセスキーのタブレベル権限制御のバックエンド機能を追加します。
UI変更は含まれていません（派生プロジェクトで実装する必要があります）。

## 変更ファイル（7ファイル）

| ファイル | 変更内容 |
|----------|----------|
| `lib/access-keys.ts` | `getUserAccessKeyPermissions()` 関数を追加 |
| `app/api/admin/access-keys/route.ts` | トランザクションで `AccessKeyPermission` に権限を保存 |
| `lib/auth/access-checker.ts` | `AccessKey.menuPaths` と `AccessKeyPermission` の両方をチェック |
| `app/api/admin/modules/route.ts` | allowAccessKey 設定をレスポンスに含める |
| `app/api/admin/modules/access-key/route.ts` | allowAccessKey 設定更新API（新規） |
| `lib/core-modules/system/module.tsx` | 未使用メニュー定義を削除 |
| `lib/services/audit-service.ts` | `ACCESS_KEY_PERMISSION_UPDATE` アクション追加 |

## 含まれない変更

以下はプロジェクト固有の実装が必要なため、このPRには含まれていません：

- `AdminClient.tsx` - allowAccessKey設定UI
- `Header.tsx` - タブフィルタリングUI
- `layout.tsx` - tabPermissionsの伝達
- `middleware.ts` - ルート保護の変更

## 派生プロジェクトでの実装ガイド

### 1. Headerでのタブフィルタリング

```typescript
// components/Header.tsx
interface HeaderProps {
  accessKeyTabPermissions?: Record<string, string[]>;
}

const filterTabsByPermission = (tabs: TabItem[], menuPath: string) => {
  if (isAdminRole) return tabs;
  const allowedTabIds = accessKeyTabPermissions[menuPath];
  if (!allowedTabIds?.length) return tabs;
  return tabs.filter(tab => {
    const tabId = new URL(tab.path, "http://localhost").searchParams.get("tab");
    return tabId && allowedTabIds.includes(tabId);
  });
};
```

### 2. layout.tsxでの権限取得

```typescript
import { getUserAccessKeyPermissions } from "@/lib/access-keys";

const accessKeyPermissions = await getUserAccessKeyPermissions(session.user.id);
<Header accessKeyTabPermissions={accessKeyPermissions.tabPermissions} />
```

## Test plan

- [ ] アクセスキー作成時にpermissions配列が正しく保存されることを確認
- [ ] `getUserAccessKeyPermissions()` がタブ権限を正しく返すことを確認
- [ ] `/api/admin/modules` がallowAccessKey設定を返すことを確認
- [ ] `/api/admin/modules/access-key` で設定が更新できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)