### PR TITLE
feat: フローティングサブウィンドウ機能を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -560,6 +560,85 @@ OAuth認証は管理画面（システム情報タブ）で個別に有効化/�
 3. LdapMigrationServiceで認証（Legacy LDAP + OpenLDAP対応）
 4. JWTトークン発行
 
+## フローティングウィンドウ（フレーム基盤）
+
+メイン画面と同時に操作可能なフローティングサブウィンドウを提供するフレーム基盤機能です。
+
+### 機能
+
+| 機能 | 説明 |
+|------|------|
+| ドラッグ移動 | タイトルバーをドラッグして移動 |
+| リサイズ | 四辺・四隅をドラッグしてサイズ変更 |
+| 最小化 | タスクバー風に左下に最小表示 |
+| 最大化 | 全画面表示（タイトルバーダブルクリックでも可） |
+| 閉じる | ボタンまたはESCキーで閉じる |
+
+### 使用方法
+
+```typescript
+"use client";
+
+import { FloatingWindow } from "@/components/ui/floating-window";
+import { useFloatingWindowStore } from "@/lib/stores/floating-window-store";
+
+export default function MyPage() {
+  const { open, isOpen } = useFloatingWindowStore();
+
+  const handleOpen = () => {
+    open({
+      title: "Window Title",
+      titleJa: "ウィンドウタイトル",
+      content: (
+        <div>
+          {/* ウィンドウ内のコンテンツ */}
+          <p>Your content here</p>
+        </div>
+      ),
+      initialPosition: { x: 200, y: 150 },  // 初期位置（オプション）
+      initialSize: { width: 450, height: 400 },  // 初期サイズ（オプション）
+    });
+  };
+
+  return (
+    <div>
+      <button onClick={handleOpen} disabled={isOpen}>
+        Open Window
+      </button>
+      {/* ページの最後にFloatingWindowを配置 */}
+      <FloatingWindow language="ja" />
+    </div>
+  );
+}
+```
+
+### ストアAPI
+
+```typescript
+const {
+  isOpen,       // ウィンドウが開いているか
+  isMinimized,  // 最小化されているか
+  isMaximized,  // 最大化されているか
+  position,     // 現在位置 { x, y }
+  size,         // 現在サイズ { width, height }
+  open,         // ウィンドウを開く
+  close,        // ウィンドウを閉じる
+  minimize,     // 最小化
+  maximize,     // 最大化
+  restore,      // 最小化/最大化から復元
+  setPosition,  // 位置を設定
+  setSize,      // サイズを設定
+  setContent,   // コンテンツを変更
+} = useFloatingWindowStore();
+```
+
+### 注意事項
+
+- サブウィンドウは1つのみ（複数同時表示は非対応）
+- z-index: 100（Header上、BaseModal下）
+- メイン画面は同時操作可能（背景クリックで閉じない）
+- ESCキーで閉じる（最小化中は無効）
+
 ## 通知機能（フレーム基盤）
 
 通知機能はモジュールではなく、フレーム基盤として提供されます。

--- a/components/ui/floating-window.tsx
+++ b/components/ui/floating-window.tsx
@@ -1,0 +1,333 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
+import { CloseIcon } from "@/components/ui/Icons";
+import {
+  MIN_SIZE,
+  useFloatingWindowStore,
+} from "@/lib/stores/floating-window-store";
+
+interface FloatingWindowProps {
+  language?: "en" | "ja";
+}
+
+type ResizeDirection = "n" | "s" | "e" | "w" | "ne" | "nw" | "se" | "sw";
+
+export function FloatingWindow({ language = "en" }: FloatingWindowProps) {
+  const {
+    isOpen,
+    isMinimized,
+    isMaximized,
+    position,
+    size,
+    title,
+    titleJa,
+    content,
+    close,
+    minimize,
+    maximize,
+    restore,
+    setPosition,
+    setSize,
+  } = useFloatingWindowStore();
+
+  const windowRef = useRef<HTMLDivElement>(null);
+  const isDraggingRef = useRef(false);
+  const isResizingRef = useRef(false);
+  const resizeDirectionRef = useRef<ResizeDirection | null>(null);
+  const dragStartRef = useRef({ x: 0, y: 0 });
+  const initialPosRef = useRef({ x: 0, y: 0 });
+  const initialSizeRef = useRef({ width: 0, height: 0 });
+
+  // ドラッグ開始
+  const handleDragStart = useCallback(
+    (e: React.MouseEvent) => {
+      if (isMaximized) return;
+      e.preventDefault();
+      isDraggingRef.current = true;
+      dragStartRef.current = { x: e.clientX, y: e.clientY };
+      initialPosRef.current = { ...position };
+      document.body.style.cursor = "move";
+      document.body.style.userSelect = "none";
+    },
+    [position, isMaximized],
+  );
+
+  // リサイズ開始
+  const handleResizeStart = useCallback(
+    (direction: ResizeDirection) => (e: React.MouseEvent) => {
+      if (isMaximized) return;
+      e.preventDefault();
+      e.stopPropagation();
+      isResizingRef.current = true;
+      resizeDirectionRef.current = direction;
+      dragStartRef.current = { x: e.clientX, y: e.clientY };
+      initialPosRef.current = { ...position };
+      initialSizeRef.current = { ...size };
+      document.body.style.userSelect = "none";
+    },
+    [position, size, isMaximized],
+  );
+
+  // マウス移動・リリースのイベントハンドラ
+  useEffect(() => {
+    const handleMouseMove = (e: MouseEvent) => {
+      // ドラッグ中
+      if (isDraggingRef.current) {
+        const deltaX = e.clientX - dragStartRef.current.x;
+        const deltaY = e.clientY - dragStartRef.current.y;
+        setPosition({
+          x: Math.max(0, initialPosRef.current.x + deltaX),
+          y: Math.max(0, initialPosRef.current.y + deltaY),
+        });
+      }
+
+      // リサイズ中
+      if (isResizingRef.current && resizeDirectionRef.current) {
+        const deltaX = e.clientX - dragStartRef.current.x;
+        const deltaY = e.clientY - dragStartRef.current.y;
+        const dir = resizeDirectionRef.current;
+
+        let newWidth = initialSizeRef.current.width;
+        let newHeight = initialSizeRef.current.height;
+        let newX = initialPosRef.current.x;
+        let newY = initialPosRef.current.y;
+
+        // 方向に応じたサイズ・位置計算
+        if (dir.includes("e")) newWidth += deltaX;
+        if (dir.includes("w")) {
+          newWidth -= deltaX;
+          newX += deltaX;
+        }
+        if (dir.includes("s")) newHeight += deltaY;
+        if (dir.includes("n")) {
+          newHeight -= deltaY;
+          newY += deltaY;
+        }
+
+        // 最小サイズの制限を適用
+        if (newWidth >= MIN_SIZE.width) {
+          setSize({ width: newWidth, height: size.height });
+          if (dir.includes("w")) {
+            setPosition({ x: newX, y: position.y });
+          }
+        }
+        if (newHeight >= MIN_SIZE.height) {
+          setSize({ width: size.width, height: newHeight });
+          if (dir.includes("n")) {
+            setPosition({ x: position.x, y: newY });
+          }
+        }
+        // 両方同時に更新
+        if (newWidth >= MIN_SIZE.width && newHeight >= MIN_SIZE.height) {
+          setSize({ width: newWidth, height: newHeight });
+          if (dir.includes("w") || dir.includes("n")) {
+            setPosition({ x: newX, y: newY });
+          }
+        }
+      }
+    };
+
+    const handleMouseUp = () => {
+      isDraggingRef.current = false;
+      isResizingRef.current = false;
+      resizeDirectionRef.current = null;
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+    };
+
+    document.addEventListener("mousemove", handleMouseMove);
+    document.addEventListener("mouseup", handleMouseUp);
+
+    return () => {
+      document.removeEventListener("mousemove", handleMouseMove);
+      document.removeEventListener("mouseup", handleMouseUp);
+    };
+  }, [setPosition, setSize, position, size]);
+
+  // ESCキーで閉じる
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && isOpen && !isMinimized) {
+        close();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, isMinimized, close]);
+
+  // SSR対策
+  if (typeof window === "undefined") return null;
+  if (!isOpen) return null;
+
+  const displayTitle = language === "ja" ? titleJa : title;
+
+  // 最小化時はタスクバー風の表示
+  if (isMinimized) {
+    return createPortal(
+      <button
+        type="button"
+        className="fixed bottom-4 left-4 z-[100] bg-card border border-border rounded-lg shadow-lg cursor-pointer hover:bg-accent transition-colors"
+        onClick={restore}
+      >
+        <div className="px-4 py-2 flex items-center gap-2">
+          <span className="text-sm font-medium">{displayTitle}</span>
+          <span className="text-xs text-muted-foreground">
+            {language === "ja" ? "クリックで復元" : "Click to restore"}
+          </span>
+        </div>
+      </button>,
+      document.body,
+    );
+  }
+
+  // リサイズハンドルの共通スタイル
+  const resizeHandleClass =
+    "absolute bg-transparent hover:bg-primary/20 transition-colors";
+
+  const windowContent = (
+    <div
+      ref={windowRef}
+      className="fixed z-[100] bg-card border border-border rounded-lg shadow-xl flex flex-col overflow-hidden"
+      style={{
+        left: isMaximized ? 0 : position.x,
+        top: isMaximized ? 0 : position.y,
+        width: isMaximized ? "100vw" : size.width,
+        height: isMaximized ? "100vh" : size.height,
+      }}
+    >
+      {/* タイトルバー */}
+      <div
+        className="flex-shrink-0 flex items-center justify-between px-4 py-2 bg-muted border-b border-border cursor-move select-none"
+        onMouseDown={handleDragStart}
+        onDoubleClick={() => (isMaximized ? restore() : maximize())}
+      >
+        <h3 className="text-sm font-semibold text-foreground truncate">
+          {displayTitle}
+        </h3>
+        <div className="flex items-center gap-1">
+          {/* 最小化ボタン */}
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              minimize();
+            }}
+            className="p-1 text-muted-foreground hover:text-foreground hover:bg-accent rounded transition-colors"
+            aria-label={language === "ja" ? "最小化" : "Minimize"}
+          >
+            <svg
+              className="w-4 h-4"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+            >
+              <path strokeLinecap="round" strokeWidth={2} d="M5 12h14" />
+            </svg>
+          </button>
+          {/* 最大化/復元ボタン */}
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              isMaximized ? restore() : maximize();
+            }}
+            className="p-1 text-muted-foreground hover:text-foreground hover:bg-accent rounded transition-colors"
+            aria-label={
+              language === "ja"
+                ? isMaximized
+                  ? "元に戻す"
+                  : "最大化"
+                : isMaximized
+                  ? "Restore"
+                  : "Maximize"
+            }
+          >
+            <svg
+              className="w-4 h-4"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+            >
+              {isMaximized ? (
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M8 3H5a2 2 0 00-2 2v3m18 0V5a2 2 0 00-2-2h-3m0 18h3a2 2 0 002-2v-3M3 16v3a2 2 0 002 2h3"
+                />
+              ) : (
+                <rect
+                  x="3"
+                  y="3"
+                  width="18"
+                  height="18"
+                  rx="2"
+                  strokeWidth={2}
+                />
+              )}
+            </svg>
+          </button>
+          {/* 閉じるボタン */}
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              close();
+            }}
+            className="p-1 text-muted-foreground hover:text-destructive hover:bg-destructive/10 rounded transition-colors"
+            aria-label={language === "ja" ? "閉じる" : "Close"}
+          >
+            <CloseIcon className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+
+      {/* コンテンツエリア */}
+      <div className="flex-1 overflow-auto p-4">{content}</div>
+
+      {/* リサイズハンドル（最大化時は非表示） */}
+      {!isMaximized && (
+        <>
+          {/* 四辺 */}
+          <div
+            className={`${resizeHandleClass} top-0 left-2 right-2 h-1 cursor-n-resize`}
+            onMouseDown={handleResizeStart("n")}
+          />
+          <div
+            className={`${resizeHandleClass} bottom-0 left-2 right-2 h-1 cursor-s-resize`}
+            onMouseDown={handleResizeStart("s")}
+          />
+          <div
+            className={`${resizeHandleClass} left-0 top-2 bottom-2 w-1 cursor-w-resize`}
+            onMouseDown={handleResizeStart("w")}
+          />
+          <div
+            className={`${resizeHandleClass} right-0 top-2 bottom-2 w-1 cursor-e-resize`}
+            onMouseDown={handleResizeStart("e")}
+          />
+          {/* 四隅 */}
+          <div
+            className={`${resizeHandleClass} top-0 left-0 w-2 h-2 cursor-nw-resize`}
+            onMouseDown={handleResizeStart("nw")}
+          />
+          <div
+            className={`${resizeHandleClass} top-0 right-0 w-2 h-2 cursor-ne-resize`}
+            onMouseDown={handleResizeStart("ne")}
+          />
+          <div
+            className={`${resizeHandleClass} bottom-0 left-0 w-2 h-2 cursor-sw-resize`}
+            onMouseDown={handleResizeStart("sw")}
+          />
+          <div
+            className={`${resizeHandleClass} bottom-0 right-0 w-2 h-2 cursor-se-resize`}
+            onMouseDown={handleResizeStart("se")}
+          />
+        </>
+      )}
+    </div>
+  );
+
+  return createPortal(windowContent, document.body);
+}

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -18,4 +18,5 @@ export {
   CardHeader,
   CardTitle,
 } from "./card";
+export { FloatingWindow } from "./floating-window";
 export { AlertIcon, CloseIcon, InfoIcon, LoadingSpinner } from "./Icons";

--- a/lib/stores/floating-window-store.ts
+++ b/lib/stores/floating-window-store.ts
@@ -1,0 +1,150 @@
+import type { ReactNode } from "react";
+import { create } from "zustand";
+
+// 定数
+const DEFAULT_POSITION = { x: 100, y: 100 };
+const DEFAULT_SIZE = { width: 400, height: 300 };
+const MIN_SIZE = { width: 200, height: 150 };
+
+interface FloatingWindowPosition {
+  x: number;
+  y: number;
+}
+
+interface FloatingWindowSize {
+  width: number;
+  height: number;
+}
+
+interface OpenOptions {
+  title?: string;
+  titleJa?: string;
+  content?: ReactNode;
+  initialPosition?: FloatingWindowPosition;
+  initialSize?: FloatingWindowSize;
+}
+
+interface FloatingWindowStore {
+  // 表示状態
+  isOpen: boolean;
+  isMinimized: boolean;
+  isMaximized: boolean;
+
+  // 位置とサイズ
+  position: FloatingWindowPosition;
+  size: FloatingWindowSize;
+
+  // 最大化前の状態を保存
+  prevPosition: FloatingWindowPosition | null;
+  prevSize: FloatingWindowSize | null;
+
+  // コンテンツ
+  title: string;
+  titleJa: string;
+  content: ReactNode | null;
+
+  // アクション
+  open: (options?: OpenOptions) => void;
+  close: () => void;
+  minimize: () => void;
+  maximize: () => void;
+  restore: () => void;
+  setPosition: (position: FloatingWindowPosition) => void;
+  setSize: (size: FloatingWindowSize) => void;
+  setContent: (content: ReactNode) => void;
+}
+
+export const useFloatingWindowStore = create<FloatingWindowStore>(
+  (set, get) => ({
+    // 初期状態
+    isOpen: false,
+    isMinimized: false,
+    isMaximized: false,
+    position: DEFAULT_POSITION,
+    size: DEFAULT_SIZE,
+    prevPosition: null,
+    prevSize: null,
+    title: "Sub Window",
+    titleJa: "サブウィンドウ",
+    content: null,
+
+    open: (options) => {
+      set({
+        isOpen: true,
+        isMinimized: false,
+        isMaximized: false,
+        title: options?.title ?? "Sub Window",
+        titleJa: options?.titleJa ?? "サブウィンドウ",
+        content: options?.content ?? null,
+        position: options?.initialPosition ?? DEFAULT_POSITION,
+        size: options?.initialSize ?? DEFAULT_SIZE,
+      });
+    },
+
+    close: () => {
+      set({
+        isOpen: false,
+        isMinimized: false,
+        isMaximized: false,
+        content: null,
+        prevPosition: null,
+        prevSize: null,
+      });
+    },
+
+    minimize: () => {
+      set({ isMinimized: true, isMaximized: false });
+    },
+
+    maximize: () => {
+      const { position, size, isMaximized } = get();
+      if (!isMaximized) {
+        set({
+          prevPosition: position,
+          prevSize: size,
+          position: { x: 0, y: 0 },
+          size: {
+            width: typeof window !== "undefined" ? window.innerWidth : 1200,
+            height: typeof window !== "undefined" ? window.innerHeight : 800,
+          },
+          isMaximized: true,
+          isMinimized: false,
+        });
+      }
+    },
+
+    restore: () => {
+      const { prevPosition, prevSize, isMaximized, isMinimized } = get();
+      if (isMaximized && prevPosition && prevSize) {
+        set({
+          position: prevPosition,
+          size: prevSize,
+          isMaximized: false,
+          prevPosition: null,
+          prevSize: null,
+        });
+      } else if (isMinimized) {
+        set({ isMinimized: false });
+      }
+    },
+
+    setPosition: (position) => {
+      set({ position });
+    },
+
+    setSize: (size) => {
+      set({
+        size: {
+          width: Math.max(size.width, MIN_SIZE.width),
+          height: Math.max(size.height, MIN_SIZE.height),
+        },
+      });
+    },
+
+    setContent: (content) => {
+      set({ content });
+    },
+  }),
+);
+
+export { DEFAULT_POSITION, DEFAULT_SIZE, MIN_SIZE };


### PR DESCRIPTION
## Summary
- メイン画面と同時操作可能なフローティングサブウィンドウをフレーム基盤機能として追加
- Zustand状態管理ストアとUIコンポーネントを実装
- CLAUDE.mdに使用方法のドキュメントを追加

## Features / 機能
| 機能 | 説明 |
|------|------|
| ドラッグ移動 | タイトルバーをドラッグして移動 |
| リサイズ | 四辺・四隅をドラッグしてサイズ変更 |
| 最小化 | タスクバー風に左下に最小表示 |
| 最大化 | 全画面表示（タイトルバーダブルクリックでも可） |
| 閉じる | ボタンまたはESCキーで閉じる |

## Files Changed
- `lib/stores/floating-window-store.ts` - Zustand状態管理ストア（新規）
- `components/ui/floating-window.tsx` - UIコンポーネント（新規）
- `components/ui/index.ts` - エクスポート追加
- `CLAUDE.md` - 使用方法のドキュメント追加

## Test plan
- [x] Biomeチェック通過
- [x] 開発サーバーで動作確認
- [ ] サブウィンドウの開閉
- [ ] ドラッグ移動
- [ ] リサイズ
- [ ] 最小化・最大化・復元
- [ ] ESCキーで閉じる

🤖 Generated with [Claude Code](https://claude.com/claude-code)