### PR TITLE
feat: ビルドIDによるセッション無効化機能

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+
+/**
+ * Health check endpoint for Docker/Kubernetes
+ * GET /api/health
+ */
+export async function GET() {
+  return NextResponse.json(
+    {
+      status: "ok",
+      timestamp: new Date().toISOString(),
+      version: process.env.npm_package_version || "1.0.0",
+      buildId: process.env.NEXT_BUILD_ID || "dev",
+    },
+    { status: 200 },
+  );
+}

--- a/auth.config.ts
+++ b/auth.config.ts
@@ -1,23 +1,9 @@
-import { readFileSync } from "fs";
 import { PrismaAdapter } from "@auth/prisma-adapter";
 import type { Role } from "@prisma/client";
 import type { NextAuthConfig } from "next-auth";
 import GitHub from "next-auth/providers/github";
 import Google from "next-auth/providers/google";
 import { prisma } from "@/lib/prisma";
-
-// Read build ID once at startup for JWT embedding
-let _buildId: string | null = null;
-function getBuildId(): string {
-  if (!_buildId) {
-    try {
-      _buildId = readFileSync("build-id", "utf-8").trim();
-    } catch {
-      _buildId = "dev";
-    }
-  }
-  return _buildId;
-}
 
 // Lightweight auth config for middleware (Edge Runtime compatible)
 // Does not include LDAP/OpenLDAP providers to avoid Node.js module dependencies
@@ -155,7 +141,7 @@ export const authConfig = {
     async jwt({ token, user, trigger }) {
       // サインイン時にビルドIDを記録
       if (user) {
-        token.buildId = getBuildId();
+        token.buildId = process.env.NEXT_BUILD_ID || "dev";
       }
       // 初回ログイン時またはセッション更新時にDBからユーザ情報を取得
       if (user || trigger === "update" || !token.role) {

--- a/auth.config.ts
+++ b/auth.config.ts
@@ -1,9 +1,23 @@
+import { readFileSync } from "fs";
 import { PrismaAdapter } from "@auth/prisma-adapter";
 import type { Role } from "@prisma/client";
 import type { NextAuthConfig } from "next-auth";
 import GitHub from "next-auth/providers/github";
 import Google from "next-auth/providers/google";
 import { prisma } from "@/lib/prisma";
+
+// Read build ID once at startup for JWT embedding
+let _buildId: string | null = null;
+function getBuildId(): string {
+  if (!_buildId) {
+    try {
+      _buildId = readFileSync("build-id", "utf-8").trim();
+    } catch {
+      _buildId = "dev";
+    }
+  }
+  return _buildId;
+}
 
 // Lightweight auth config for middleware (Edge Runtime compatible)
 // Does not include LDAP/OpenLDAP providers to avoid Node.js module dependencies
@@ -139,6 +153,10 @@ export const authConfig = {
       return true;
     },
     async jwt({ token, user, trigger }) {
+      // サインイン時にビルドIDを記録
+      if (user) {
+        token.buildId = getBuildId();
+      }
       // 初回ログイン時またはセッション更新時にDBからユーザ情報を取得
       if (user || trigger === "update" || !token.role) {
         const dbUser = await prisma.user.findUnique({
@@ -181,6 +199,8 @@ export const authConfig = {
         session.user.mustChangePassword =
           (token.mustChangePassword as boolean) || false;
       }
+      // Expose buildId for middleware validation
+      (session as unknown as Record<string, unknown>).buildId = token.buildId;
       return session;
     },
   },

--- a/middleware.ts
+++ b/middleware.ts
@@ -8,11 +8,32 @@ export default auth((req) => {
   const { pathname } = req.nextUrl;
   const session = req.auth;
 
+  // Build ID mismatch helper
+  const hasBuildIdMismatch = (s: typeof session): boolean => {
+    if (!s) return false;
+    const currentBuildId = process.env.NEXT_BUILD_ID;
+    const tokenBuildId = (s as unknown as Record<string, unknown>)
+      .buildId as string | undefined;
+    return !!(
+      currentBuildId &&
+      currentBuildId !== "dev" &&
+      tokenBuildId &&
+      tokenBuildId !== currentBuildId
+    );
+  };
+
   // Public routes
   const publicRoutes = ["/", "/login"];
   if (publicRoutes.includes(pathname)) {
     // Redirect authenticated users away from login page
     if (pathname === "/login" && session) {
+      // If build ID doesn't match, clear session cookies and stay on /login
+      if (hasBuildIdMismatch(session)) {
+        const response = NextResponse.next();
+        response.cookies.delete("authjs.session-token");
+        response.cookies.delete("__Secure-authjs.session-token");
+        return response;
+      }
       // Check if 2FA is required
       if (session.user.twoFactorEnabled) {
         const verified = req.cookies.get("2fa_verified");
@@ -45,6 +66,14 @@ export default auth((req) => {
       return NextResponse.redirect(new URL("/dashboard", req.url));
     }
     return NextResponse.next();
+  }
+
+  // Build ID validation: invalidate sessions from previous deployments
+  if (session && hasBuildIdMismatch(session)) {
+    const response = NextResponse.redirect(new URL("/login", req.url));
+    response.cookies.delete("authjs.session-token");
+    response.cookies.delete("__Secure-authjs.session-token");
+    return response;
   }
 
   // Protected routes - require authentication

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,18 @@
+import { readFileSync } from "fs";
 import type { NextConfig } from "next";
 
+// Read build ID generated during Docker build (used for session invalidation on redeploy)
+let buildId = "dev";
+try {
+  buildId = readFileSync("build-id", "utf-8").trim();
+} catch {
+  // File doesn't exist in development - use "dev" as default
+}
+
 const nextConfig: NextConfig = {
+  env: {
+    NEXT_BUILD_ID: buildId,
+  },
   // Docker用のstandaloneビルド出力
   output: "standalone",
 


### PR DESCRIPTION
## Summary

- Docker本番環境で再デプロイ時に旧セッションを自動無効化するビルドID機能を追加
- `/login` ページでのリダイレクトループ防止ロジックを含む
- ヘルスチェックエンドポイント (`/api/health`) でビルドIDを確認可能に

Closes #16

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `next.config.ts` | `build-id` ファイルを読み込み `NEXT_BUILD_ID` 環境変数として公開 |
| `auth.config.ts` | JWTトークンにビルドIDを埋め込み、セッションに伝播 |
| `middleware.ts` | ビルドID不一致時のセッション無効化（パブリック/保護ルート両方） |
| `app/api/health/route.ts` | ビルドID確認用ヘルスチェックエンドポイント（新規） |

## Dockerfileでの対応（別途必要）

本PRにはDockerfileは含まれていません。本番環境で利用するには、Dockerfileに以下を追加する必要があります:

```dockerfile
# ビルドステージでビルドIDを生成
RUN echo "BUILD_$(date +%Y%m%d_%H%M%S)" > /app/build-id

# ランナーステージにビルドIDファイルをコピー
COPY --from=builder /app/build-id ./build-id
```

## 開発環境への影響

- `build-id` ファイルが存在しない場合、ビルドIDは `"dev"` となり検証はスキップされる
- 開発環境には一切影響なし

## 参考実装

ted-box2での実装・運用実績あり: https://github.com/Takashi-Matsumura/ted-box2/commit/23118a8

## Test plan

- [ ] 開発環境で `build-id` ファイルなしの場合、セッション検証がスキップされることを確認
- [ ] `/api/health` でビルドIDが `"dev"` と返ることを確認
- [ ] Docker環境でビルド後、`/api/health` にタイムスタンプベースのビルドIDが返ることを確認
- [ ] Docker再デプロイ後、旧セッションで `/dashboard` にアクセスすると `/login` にリダイレクトされることを確認
- [ ] リダイレクトループが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)