### PR TITLE
feat: サイドバーナビゲーションにローディング表示を追加

### DIFF
--- a/components/AppSidebar.tsx
+++ b/components/AppSidebar.tsx
@@ -6,6 +6,7 @@ import { useSidebarStore } from "@/lib/stores/sidebar-store";
 import type { AppMenu } from "@/types/module";
 import { SidebarHeaderContent } from "./sidebar/SidebarHeaderContent";
 import { SidebarMenuGroup } from "./sidebar/SidebarMenuGroup";
+import { SidebarNavigationProvider } from "./sidebar/SidebarNavigationContext";
 import { SidebarUserSection } from "./sidebar/SidebarUserSection";
 
 interface AppSidebarProps {
@@ -33,39 +34,41 @@ export function AppSidebar({
   const isAdmin = session.user.role === "ADMIN";
 
   return (
-    <Sidebar
-      collapsible="icon"
-      className="border-r border-sidebar-border"
-      style={
-        {
-          "--sidebar-width": `${width}px`,
-        } as React.CSSProperties
-      }
-    >
-      <SidebarHeaderContent language={language} />
+    <SidebarNavigationProvider>
+      <Sidebar
+        collapsible="icon"
+        className="border-r border-sidebar-border"
+        style={
+          {
+            "--sidebar-width": `${width}px`,
+          } as React.CSSProperties
+        }
+      >
+        <SidebarHeaderContent language={language} />
 
-      <SidebarContent>
-        {menuGroups.map((group) => {
-          const menus = groupedMenus[group.id] || [];
-          return (
-            <SidebarMenuGroup
-              key={group.id}
-              group={group}
-              menus={menus}
-              language={language}
-              isAdmin={isAdmin}
-            />
-          );
-        })}
-      </SidebarContent>
+        <SidebarContent>
+          {menuGroups.map((group) => {
+            const menus = groupedMenus[group.id] || [];
+            return (
+              <SidebarMenuGroup
+                key={group.id}
+                group={group}
+                menus={menus}
+                language={language}
+                isAdmin={isAdmin}
+              />
+            );
+          })}
+        </SidebarContent>
 
-      <SidebarUserSection
-        session={session}
-        language={language}
-        mustChangePassword={mustChangePassword}
-      />
+        <SidebarUserSection
+          session={session}
+          language={language}
+          mustChangePassword={mustChangePassword}
+        />
 
-      <SidebarRail />
-    </Sidebar>
+        <SidebarRail />
+      </Sidebar>
+    </SidebarNavigationProvider>
   );
 }

--- a/components/sidebar/SidebarMenuItem.tsx
+++ b/components/sidebar/SidebarMenuItem.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ChevronRight, Key } from "lucide-react";
+import { ChevronRight, Key, Loader2 } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useState } from "react";
@@ -17,6 +17,7 @@ import {
   SidebarMenuSubItem,
 } from "@/components/ui/sidebar";
 import type { AppMenu } from "@/types/module";
+import { useSidebarNavigation } from "./SidebarNavigationContext";
 
 // TailwindクラスからHEX値へのマッピング
 const colorMap: Record<string, string> = {
@@ -42,15 +43,36 @@ export function SidebarMenuItemComponent({
 }: SidebarMenuItemComponentProps) {
   const [isExpanded, setIsExpanded] = useState(false);
   const pathname = usePathname();
+  const { loadingPath, setLoadingPath } = useSidebarNavigation();
 
   const hasChildren = menu.children && menu.children.length > 0;
   const label = language === "ja" ? menu.nameJa : menu.name;
   const isImplemented = menu.isImplemented !== false;
   const isAccessKeyGranted = menu.isAccessKeyGranted === true;
   const isActive = pathname === menu.path;
+  const isLoading = loadingPath === menu.path;
+
+  // メニュークリック時のハンドラ
+  const handleMenuClick = (path: string) => {
+    // 現在のパスと同じ場合はローディング表示しない
+    if (pathname !== path) {
+      setLoadingPath(path);
+    }
+  };
 
   // メニューアイコンのレンダリング
-  const renderIcon = () => {
+  const renderIcon = (forPath?: string) => {
+    const isItemLoading = forPath ? loadingPath === forPath : isLoading;
+
+    // ローディング中はスピナーを表示
+    if (isItemLoading) {
+      return (
+        <div className="relative flex items-center justify-center size-5">
+          <Loader2 className="size-4 animate-spin text-primary" />
+        </div>
+      );
+    }
+
     if (!menu.icon) return null;
 
     // TailwindクラスをHEX値に変換
@@ -101,20 +123,29 @@ export function SidebarMenuItemComponent({
           </CollapsibleTrigger>
           <CollapsibleContent>
             <SidebarMenuSub>
-              {menu.children?.map((child) => (
-                <SidebarMenuSubItem key={child.id}>
-                  <SidebarMenuSubButton
-                    asChild
-                    isActive={pathname === child.path}
-                  >
-                    <Link href={child.path}>
-                      <span>
-                        {language === "ja" ? child.nameJa : child.name}
-                      </span>
-                    </Link>
-                  </SidebarMenuSubButton>
-                </SidebarMenuSubItem>
-              ))}
+              {menu.children?.map((child) => {
+                const isChildLoading = loadingPath === child.path;
+                return (
+                  <SidebarMenuSubItem key={child.id}>
+                    <SidebarMenuSubButton
+                      asChild
+                      isActive={pathname === child.path}
+                    >
+                      <Link
+                        href={child.path}
+                        onClick={() => handleMenuClick(child.path)}
+                      >
+                        {isChildLoading && (
+                          <Loader2 className="size-3 animate-spin text-primary mr-1" />
+                        )}
+                        <span>
+                          {language === "ja" ? child.nameJa : child.name}
+                        </span>
+                      </Link>
+                    </SidebarMenuSubButton>
+                  </SidebarMenuSubItem>
+                );
+              })}
             </SidebarMenuSub>
           </CollapsibleContent>
         </SidebarMenuItem>
@@ -131,7 +162,7 @@ export function SidebarMenuItemComponent({
         isActive={isActive}
         className={!isImplemented ? "opacity-60" : ""}
       >
-        <Link href={menu.path}>
+        <Link href={menu.path} onClick={() => handleMenuClick(menu.path)}>
           {renderIcon()}
           <span className="truncate">{label}</span>
           {isAccessKeyGranted && (

--- a/components/sidebar/SidebarNavigationContext.tsx
+++ b/components/sidebar/SidebarNavigationContext.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from "react";
+import { usePathname } from "next/navigation";
+
+interface SidebarNavigationContextType {
+  loadingPath: string | null;
+  setLoadingPath: (path: string | null) => void;
+}
+
+const SidebarNavigationContext =
+  createContext<SidebarNavigationContextType | null>(null);
+
+export function SidebarNavigationProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const [loadingPath, setLoadingPath] = useState<string | null>(null);
+  const pathname = usePathname();
+
+  // パスが変わったらローディング状態をクリア
+  useEffect(() => {
+    if (loadingPath && pathname === loadingPath) {
+      setLoadingPath(null);
+    }
+  }, [pathname, loadingPath]);
+
+  // 一定時間経過後もローディングが続いていたらクリア（フォールバック）
+  useEffect(() => {
+    if (loadingPath) {
+      const timeout = setTimeout(() => {
+        setLoadingPath(null);
+      }, 10000); // 10秒でタイムアウト
+      return () => clearTimeout(timeout);
+    }
+  }, [loadingPath]);
+
+  return (
+    <SidebarNavigationContext.Provider value={{ loadingPath, setLoadingPath }}>
+      {children}
+    </SidebarNavigationContext.Provider>
+  );
+}
+
+export function useSidebarNavigation() {
+  const context = useContext(SidebarNavigationContext);
+  // プロバイダー外で使用された場合はフォールバック（ローディング表示なし）
+  if (!context) {
+    return {
+      loadingPath: null,
+      setLoadingPath: () => {},
+    };
+  }
+  return context;
+}


### PR DESCRIPTION
## Summary

- メニューをクリックした際、ページのレンダリングが完了するまでローディングスピナーを表示
- ユーザーがメニューをクリック後、画面が切り替わるまでの間の不安を解消
- 複数回のクリックによるサーバー負荷を軽減

## Changes

- `SidebarNavigationContext.tsx`: ナビゲーション状態を管理するコンテキストを新規作成
- `SidebarMenuItem.tsx`: ローディング中はアイコンの代わりにスピナーを表示
- `AppSidebar.tsx`: `SidebarNavigationProvider`でラップ

## Features

- クリック時にローディングパスを設定、遷移完了時に自動クリア
- 10秒のタイムアウトフォールバック（万が一の場合に備える）
- 子メニュー（サブメニュー）にも対応
- 現在のページと同じメニューをクリックした場合はローディング表示しない

## Test plan

- [ ] メニューをクリックしてスピナーが表示されることを確認
- [ ] ページ遷移完了後にスピナーが消えることを確認
- [ ] 子メニューでも同様に動作することを確認
- [ ] 同じページのメニューをクリックした場合はスピナーが表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)